### PR TITLE
Allow access from outside localhost

### DIFF
--- a/templates/pg_hba.conf.j2
+++ b/templates/pg_hba.conf.j2
@@ -6,3 +6,4 @@ local   all             postgres                                trust
 local   all             all                                     peer
 host    all             all             127.0.0.1/32            md5
 host    all             all             ::1/128                 md5
+{% if group_env == 'local' %}host    all             all             0.0.0.0/0               trust{% endif %}

--- a/templates/postgresql.conf.j2
+++ b/templates/postgresql.conf.j2
@@ -7,6 +7,10 @@ ident_file = '/etc/postgresql/{{ postgresql.version }}/main/pg_ident.conf'
 
 external_pid_file = '/var/run/postgresql/{{ postgresql.version }}-main.pid'
 
+{% if group_env == 'local' %}
+listen_addresses = '*'
+{% endif %}
+
 port = {{ postgresql.port }}
 
 max_connections = {{ postgresql.max_connections }}


### PR DESCRIPTION
Allows access from other hosts when `group_env` is `local`